### PR TITLE
Check obj_file / probin for c functions

### DIFF
--- a/src/extension/pg_proc.rs
+++ b/src/extension/pg_proc.rs
@@ -31,6 +31,7 @@ DbStruct! {
 		proconfig: Option<ClassOptions>,
 		proacl: Option<Text> = ("proacl::text"),
 		comment: Option<Text> = ("obj_description(p.oid, 'pg_proc')"),
+		probin: Option<Text>,
 	}
 }
 


### PR DESCRIPTION
Hi again!

I believe it should be possible to catch mismatches between the `obj_file` parameter for dynamically loadable C language functions.

Example: I accidentally used the wrong `obj_file` for a function in an upgrade script. See https://github.com/zachasme/h3-pg/issues/117. It didn't fail because there exists a function with the same name in both shared library files.

I've tested the change locally and it correctly catches the error:

```
      - mismatch found for Routine public.h3_cell_to_boundary_wkb(cell public.h3index):
        - in probin:
          - h3_postgis
          + h3
```

 I'm not sure how to include a proper test for this PR though. What would be the right way to do so?

Cheers!