### PR TITLE
Fix compatibility with pg 9.5 and lower

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -384,13 +384,16 @@ macro_rules! DbStruct {
                             || typname == "classoptions"
                         {
                             typname = String::from("text[]");
+                        } else if typname == "option<text>" {
+                            // FIXME should find a way to handle any Option<>
+                            typname = String::from("text");
                         }
+
                         tlist.push(format!(
                                 "NULL::{} AS {}",
                                 typname,
                                 stringify!($field),
-                        )
-                        );
+                        ));
                     }
                 )*
                     tlist


### PR DESCRIPTION
The automatic tlist implementation doesn't cope well with fields defined as Option, as it relies on stringify to generate the target SQL type.

For now just intercept any field defined as Option<Text>, as the only problems happens in pg_aggregate.rs on pg 9.5 and below, but I should eventually find a better solution.