### PR TITLE
fix proc_prototype behavior with invalid oid

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -36,8 +36,8 @@ macro_rules! opr_prototype {
 macro_rules! proc_prototype {
     ($field:literal) => {
         format!(
-            "{field}::regproc::text || '(' || \
-            pg_get_function_arguments({field}) || ')'",
+            "CASE WHEN {field} = 0 THEN NULL::text ELSE {field}::regproc::text || '(' || \
+            pg_get_function_arguments({field}) || ')' END",
             field = $field
         )
     };


### PR DESCRIPTION
If a procedure is optional, it will usually be represented as 0 / InvalidOid. In that case trying to cast it to regproc will fail so check for it and explicitly reutnr a NULL instead.