### PR TITLE
Fix pg 9.4 compatibility

### DIFF
--- a/src/extension/pg_class.rs
+++ b/src/extension/pg_class.rs
@@ -31,7 +31,7 @@ DbStruct! {
         relchecks: Smallint,
         relhasrules: Bool,
         relhastriggers: Bool,
-        relrowsecurity: Bool {PG_9_4..},
+        relrowsecurity: Bool {PG_9_5..},
         relforcerowsecurity: Bool {PG_9_4..},
         relispopulated: Bool {PG_9_3..},
         relreplident: Char {PG_9_4..},


### PR DESCRIPTION
pg_class.relrowsecurity was introduced in pg 9.5, not pg 9.4.